### PR TITLE
Fix: Change eventHandler binding method

### DIFF
--- a/library/CBD/component.js
+++ b/library/CBD/component.js
@@ -1,4 +1,4 @@
-import addEventHandlers from './eventHandler.js';
+import { holdEventHandlers } from './eventHandler.js';
 import { useLocalState, useEffect } from './state.js';
 
 class Component {
@@ -6,7 +6,7 @@ class Component {
     this.props = props;
     this.useState = useLocalState;
     this.useEffect = useEffect;
-    this.setEvent && addEventHandlers(this.setEvent());
+    this.setEvent && holdEventHandlers(this.setEvent());
   }
 
   render() {

--- a/library/CBD/render.js
+++ b/library/CBD/render.js
@@ -1,3 +1,5 @@
+import { bindEventHandlers, unbindEventHandlers } from './eventHandler.js';
+
 const reconciliation = ($virtualNode, $realNode) => {
   if ($virtualNode.nodeType !== $realNode.nodeType) {
     $realNode.replaceWith($virtualNode);
@@ -76,12 +78,16 @@ const render = ($rootContainer, rootComponent) => {
     RootComponent = rootComponent;
   }
 
+  unbindEventHandlers();
+
   const domStr = new RootComponent().render();
   if (typeof domStr === 'string') {
     const $virtualRoot = $realRoot.cloneNode(false);
     $virtualRoot.innerHTML = domStr;
     reconciliation($virtualRoot, $realRoot);
   }
+
+  bindEventHandlers();
 };
 
 export default render;

--- a/library/CBD/state.js
+++ b/library/CBD/state.js
@@ -27,6 +27,7 @@ const useLocalState = initialState => {
     render();
   };
   hookIdx += 1;
+  // console.log(hooks[currentHookIdx]);
   return [hooks[currentHookIdx], setState];
 };
 


### PR DESCRIPTION
- 이벤트 핸들러들이 최신 상태값을 참조할 수 있도록 바인딩 방법을 수정하였습니다
- 기존: 중복검사 + 최초 1회 등록
- 수정: 렌더링마다 기존에 등록된 핸들러를 모두 지우고 새로 등록