### PR TITLE
Fix: Restructure CBD library

### DIFF
--- a/library/CBD/component.js
+++ b/library/CBD/component.js
@@ -1,16 +1,44 @@
 import { holdEventHandlers } from './eventHandler.js';
-import { useLocalState, useEffect } from './state.js';
+import render from './render.js';
 
 class Component {
   constructor(props) {
     this.props = props;
-    this.useState = useLocalState;
-    this.useEffect = useEffect;
-    this.setEvent && holdEventHandlers(this.setEvent());
+    this.state = null;
+    this.componentId = self.crypto.randomUUID();
+
+    this.updateEventHandlers();
+  }
+
+  setState(nextState) {
+    this.state = typeof nextState === 'function' ? nextState(this.state) : nextState;
+
+    render(document.querySelector(`[data-id=${this.componentId}]`), this);
   }
 
   render() {
-    throw new Error('render함수를 써라!');
+    return this.labelDOMStr(this.DOMStr());
+  }
+
+  DOMStr() {
+    throw new Error('domStr함수를 써라!');
+  }
+
+  labelDOMStr(DOMStr) {
+    const openTagRegex = /<[^>]*>/;
+    return DOMStr.replace(openTagRegex, openTag => `${openTag.slice(0, -1)} data-component-id=${this.componentId}/>`);
+  }
+
+  updateEventHandlers() {
+    if (!this.setEvent) {
+      return;
+    }
+    const labeledHandlerInfo = this.setEvent().map(handlerInfo => ({
+      id: this.componentId,
+      ...handlerInfo,
+    }));
+
+    holdEventHandlers(labeledHandlerInfo);
   }
 }
 

--- a/library/CBD/eventHandler.js
+++ b/library/CBD/eventHandler.js
@@ -35,37 +35,33 @@ let handlersHolder = [];
 const holdEventHandlers = eventHandlers => {
   validateEventHandler(eventHandlers);
   eventHandlers.forEach(eventHandler => {
-    const { type, selector, handler } = eventHandler;
+    const { selector, handler } = eventHandler;
 
-    const isDuplicated = handlersHolder.find(
-      ({ holdedType, holdedSlector }) => holdedType === type && holdedSlector === selector
-    );
-    if (isDuplicated) {
-      return;
-    }
-
-    const newHandler = e => {
+    eventHandler.handler = e => {
       if (selector === 'window' || selector === 'document' || e.target.closest(selector)) {
         handler(e);
       }
     };
-    eventHandler.handler = newHandler;
 
-    handlersHolder.push({ type, selector, handler: newHandler });
+    handlersHolder.push(eventHandler);
   });
 };
 
-const unbindEventHandlers = () => {
-  handlersHolder.forEach(({ type, handler }) => {
-    window.removeEventListener(type, handler);
+const updateEventHandlers = () => {
+  const removeHandlers = [];
+
+  handlersHolder.forEach(handlerInfo => {
+    const { id, type, handler } = handlerInfo;
+
+    if (document.querySelector(`[data-component-id=${id}]`)) {
+      window.addEventListener(type, handler);
+    } else {
+      window.removeEventListener(type, handler);
+      removeHandlers.push(handlerInfo);
+    }
   });
-  handlersHolder = [];
+
+  handlersHolder = handlersHolder.filter(handlerInfo => !removeHandlers.includes(handlerInfo));
 };
 
-const bindEventHandlers = () => {
-  handlersHolder.forEach(({ type, handler }) => {
-    window.addEventListener(type, handler);
-  });
-};
-
-export { unbindEventHandlers, bindEventHandlers, holdEventHandlers };
+export { updateEventHandlers, holdEventHandlers };

--- a/library/CBD/index.js
+++ b/library/CBD/index.js
@@ -1,5 +1,5 @@
 import render from './render.js';
 import Component from './component.js';
-import { useGlobalState } from './state.js';
+import useGlobalState from './state.js';
 
 export { render, Component, useGlobalState };

--- a/library/CBD/render.js
+++ b/library/CBD/render.js
@@ -1,4 +1,4 @@
-import { bindEventHandlers, unbindEventHandlers } from './eventHandler.js';
+import { updateEventHandlers } from './eventHandler';
 
 const reconciliation = ($virtualNode, $realNode) => {
   if ($virtualNode.nodeType !== $realNode.nodeType) {
@@ -68,26 +68,28 @@ const reconciliation = ($virtualNode, $realNode) => {
 };
 
 let $realRoot = null;
-let RootComponent = null;
+let RootComponentInstance = null;
 
-const render = ($rootContainer, rootComponent) => {
-  if ($rootContainer) {
-    $realRoot = $rootContainer;
+const render = ($container, componentInstance) => {
+  if ($container && !$realRoot) {
+    $realRoot = $container;
   }
-  if (rootComponent) {
-    RootComponent = rootComponent;
+  if (componentInstance && !RootComponentInstance) {
+    RootComponentInstance = componentInstance;
   }
 
-  unbindEventHandlers();
+  const $targetContainer = $container ?? $realRoot;
+  const CurrentInstance = componentInstance ?? RootComponentInstance;
 
-  const domStr = new RootComponent().render();
+  const domStr = CurrentInstance.render();
   if (typeof domStr === 'string') {
-    const $virtualRoot = $realRoot.cloneNode(false);
+    const $virtualRoot = $targetContainer.cloneNode(false);
     $virtualRoot.innerHTML = domStr;
-    reconciliation($virtualRoot, $realRoot);
-  }
 
-  bindEventHandlers();
+    reconciliation($virtualRoot, $targetContainer);
+
+    updateEventHandlers();
+  }
 };
 
 export default render;

--- a/library/CBD/state.js
+++ b/library/CBD/state.js
@@ -1,41 +1,42 @@
 import render from './render.js';
 
-const hooks = [];
-let hookIdx = 0;
+// const hooks = [];
+// let hookIdx = 0;
 
-const resetHookIdx = () => {
-  hookIdx = 0;
-};
+// const resetHookIdx = () => {
+//   hookIdx = 0;
+// };
+// const resetHooks
 
-const useEffect = (callback, depArray) => {
-  const currentHookIdx = hookIdx;
-  const hasNoDeps = !depArray;
-  const _deps = hooks[currentHookIdx];
-  const hasDepsChanged = _deps ? !depArray.every((el, idx) => el === _deps[idx]) : true;
+// const useEffect = (callback, depArray) => {
+//   const currentHookIdx = hookIdx;
+//   const hasNoDeps = !depArray;
+//   const _deps = hooks[currentHookIdx];
+//   const hasDepsChanged = _deps ? !depArray.every((el, idx) => el === _deps[idx]) : true;
 
-  if (hasNoDeps || hasDepsChanged) {
-    callback();
-    hooks[currentHookIdx] = depArray;
-  }
-  hookIdx += 1;
-};
+//   if (hasNoDeps || hasDepsChanged) {
+//     callback();
+//     hooks[currentHookIdx] = depArray;
+//   }
+//   hookIdx += 1;
+// };
 
-const useLocalState = initialState => {
-  console.log(hooks);
-  hooks[hookIdx] = hooks[hookIdx] || initialState;
+// const useLocalState = initialState => {
+//   hooks[hookIdx] = hooks[hookIdx] || initialState;
 
-  const currentHookIdx = hookIdx;
+//   const currentHookIdx = hookIdx;
 
-  const setState = nextState => {
-    hooks[currentHookIdx] = typeof nextState === 'function' ? nextState(hooks[currentHookIdx]) : nextState;
+//   const setState = nextState => {
+//     hooks[currentHookIdx] = typeof nextState === 'function' ? nextState(hooks[currentHookIdx]) : nextState;
 
-    resetHookIdx();
-    render();
-  };
-  hookIdx += 1;
+//     resetHookIdx();
+//     render();
+//   };
+//   console.log(hooks, hookIdx);
+//   hookIdx += 1;
 
-  return [hooks[currentHookIdx], setState];
-};
+//   return [hooks[currentHookIdx], setState];
+// };
 
 const useGlobalState = initialState => {
   let state = initialState;
@@ -44,11 +45,11 @@ const useGlobalState = initialState => {
   const setState = nextState => {
     state = typeof nextState === 'function' ? nextState(state) : nextState;
 
-    resetHookIdx();
+    // resetHookIdx();
     render();
   };
 
   return [getState, setState];
 };
 
-export { useGlobalState, useLocalState, useEffect, resetHookIdx };
+export default useGlobalState;

--- a/library/SPA-router/router.js
+++ b/library/SPA-router/router.js
@@ -1,5 +1,4 @@
 import { render } from '../CBD/index.js';
-import { resetHookIdx } from '../CBD/state.js';
 
 let _routes = null;
 
@@ -19,12 +18,10 @@ const navigate = path => {
   }
   // resetHookIdx 임시방편. 더 좋은 방법을 생각해라!
   window.history.pushState(null, null, path);
-  resetHookIdx();
   render();
 };
 
 window.addEventListener('popstate', () => {
-  resetHookIdx();
   render();
 });
 

--- a/src/App.js
+++ b/src/App.js
@@ -23,9 +23,7 @@ export default class App extends Component {
     super();
 
     // TODO: 함수 이름 변경 필요
-    this.useEffect(() => {
-      this.init();
-    }, []);
+    this.init();
   }
 
   async init() {

--- a/src/components/Counter/Counter.js
+++ b/src/components/Counter/Counter.js
@@ -5,7 +5,7 @@ export default class Counter extends Component {
   constructor(props) {
     super(props);
 
-    [this.state, this.setState] = this.useState({ count: 0 });
+    this.state = { count: 0 };
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 import { render } from '../library/CBD/index.js';
 import App from './App.js';
 
-render(document.getElementById('root'), App);
+render(document.getElementById('root'), new App());

--- a/src/pages/Members/MemberList.js
+++ b/src/pages/Members/MemberList.js
@@ -7,13 +7,14 @@ import { getMembers } from '../../state/index.js';
 export default class MemberList extends Component {
   render() {
     const { openModal, onUpdate, toggleEditMode } = this.props;
-
+    console.log(this.props);
     // prettier-ignore
     return `
       <ul class="${style.list}">
         ${getMembers()
           .map(member =>
-            new MemberItem({
+            new MemberItem( {
+              member,
               isEditing: this.isEditing(member.id),
               openModal,
               onUpdate,

--- a/src/pages/Members/Members.js
+++ b/src/pages/Members/Members.js
@@ -9,11 +9,11 @@ import style from './Members.module.css';
 export default class Members extends Component {
   constructor(props) {
     super(props);
-    [this.state, this.setState] = this.useState({
+    this.state = {
       removeMemberId: null,
       editingMemberIds: [],
       isModalOpen: false,
-    });
+    };
   }
 
   render() {
@@ -57,6 +57,7 @@ export default class Members extends Component {
     }
 
     addMember(name);
+    console.log(id);
     this.setState(prevState => ({
       ...prevState,
       editingMemberIds: prevState.editingMemberIds.filter(_id => _id !== id),

--- a/src/pages/NewGroup/NewGroup.js
+++ b/src/pages/NewGroup/NewGroup.js
@@ -7,10 +7,10 @@ export default class NewGroup extends Component {
   constructor(props) {
     super(props);
 
-    [this.resultState, this.setState] = this.useState({
+    this.state = {
       result: null,
       currentView: 'selectGroupCnt',
-    });
+    };
   }
 
   render() {
@@ -19,8 +19,8 @@ export default class NewGroup extends Component {
       <div class="mainContainer">
         ${
           this.resultState.currentView === 'selectGroupCnt'
-            ? new SelectGroupCnt({ setState: this.setState }).render()
-            : new Result({ resultState: this.resultState }).render()
+            ? new SelectGroupCnt({ setState: this.setState.bind(this) }).render()
+            : new Result({ resultState: this.state }).render()
         }
       </div>
     `;

--- a/src/pages/NewGroup/Result.js
+++ b/src/pages/NewGroup/Result.js
@@ -9,17 +9,18 @@ export default class Result extends Component {
   constructor(props) {
     super(props);
 
-    [this.state, this.setState] = this.useState({
+    this.state = {
       $dragTarget: null,
       $targetContainer: null,
       fromListId: null,
       // 테스트를 위한 상태값 고정
       isModalOpen: false,
-    });
+    };
   }
 
   render() {
     const { result, currentView } = this.props.resultState;
+    console.log(this.props.resultState);
     // prettier-ignore
     return `
     <section class="${style.result}">

--- a/src/pages/Records/Records.js
+++ b/src/pages/Records/Records.js
@@ -8,10 +8,10 @@ export default class Records extends Component {
   constructor(props) {
     super(props);
 
-    [this.modal, this.setModal] = this.useState({
-      isOpen: false,
+    this.state = {
+      isModalOpen: false,
       recordId: null,
-    });
+    };
   }
 
   render() {
@@ -24,7 +24,7 @@ export default class Records extends Component {
           openModal: this.openModal.bind(this),
         }).render()}
         ${
-          this.modal.isOpen
+          this.state.isModalOpen
             ? new DeleteModal({
                 target: 'record',
                 onRemove: this.removeRecord.bind(this),
@@ -37,15 +37,15 @@ export default class Records extends Component {
   }
 
   removeRecord() {
-    removeRecord(this.modal.recordId);
+    removeRecord(this.state.recordId);
     this.closeModal();
   }
 
   openModal(recordId) {
-    this.setModal({ isOpen: true, recordId });
+    this.setState({ isModalOpen: true, recordId });
   }
 
   closeModal() {
-    this.setModal({ isOpen: false, recordId: null });
+    this.setState({ isModalOpen: false, recordId: null });
   }
 }

--- a/src/pages/SignInSignUp/SignIn.js
+++ b/src/pages/SignInSignUp/SignIn.js
@@ -8,12 +8,12 @@ import style from './SignInSignUp.module.css';
 export default class signIn extends Component {
   constructor(props) {
     super(props);
-    const initialSignInForm = {
+    this.initialSignInForm = {
       email: { value: '', isDirty: false },
       password: { value: '', isDirty: false },
       isSignInFailed: false,
     };
-    [this.signInForm, this.setSignInForm] = this.useState(initialSignInForm);
+    this.state = this.initialSignInForm;
   }
 
   async signIn(e) {
@@ -34,15 +34,15 @@ export default class signIn extends Component {
     } catch (err) {
       // if (err.response.status === 401) {
       // TODO: 로그인 실패시 입력창을 비워줄지 결정 필요
-      // this.setSignInForm({ isSignInFailed: true });
-      this.setSignInForm(prevState => ({ ...prevState, isSignInFailed: true }));
+      // this.setState({ isSignInFailed: true });
+      this.setState(prevState => ({ ...prevState, isSignInFailed: true }));
       // }
     }
   }
 
   render() {
-    const emailValue = this.signInForm.email.value;
-    const passwordValue = this.signInForm.password.value;
+    const emailValue = this.state.email.value;
+    const passwordValue = this.state.password.value;
     const isEmailValid = signInSchema.email.isValid(emailValue);
     const isPasswordValid = signInSchema.password.isValid(passwordValue);
 
@@ -56,7 +56,7 @@ export default class signIn extends Component {
           style.input
         }" type="text" id="email" name="email" required autocomplete="off" value="${emailValue}" />
         <div class="${style.validateError}">${
-      this.signInForm.email.isDirty && !isEmailValid ? signInSchema.email.error : ''
+      this.state.email.isDirty && !isEmailValid ? signInSchema.email.error : ''
     }</div>
       </div>
       <div class="${style.inputContainer}">
@@ -65,11 +65,11 @@ export default class signIn extends Component {
           style.input
         }" type="password" id="password" name="password" required autocomplete="off" value="${passwordValue}"/>
         <div class="${style.validateError}">${
-      this.signInForm.password.isDirty && !isPasswordValid ? signInSchema.password.error : ''
+      this.state.password.isDirty && !isPasswordValid ? signInSchema.password.error : ''
     }</div>
       </div>
       <p class="signInError ${style.authorizeError}">${
-      this.signInForm.isSignInFailed ? 'Incorrect email or password' : ''
+      this.state.isSignInFailed ? 'Incorrect email or password' : ''
     }</p>
       <button class="submit-btn ${style.submitBtn}" ${
       isEmailValid && isPasswordValid ? '' : 'disabled'
@@ -84,7 +84,7 @@ export default class signIn extends Component {
         type: 'input',
         selector: `.${style.signInForm} input`,
         handler: e => {
-          this.setSignInForm(prevState => ({
+          this.setState(prevState => ({
             ...prevState,
             [e.target.name]: { value: e.target.value, isDirty: true },
           }));
@@ -98,7 +98,7 @@ export default class signIn extends Component {
       {
         type: 'click',
         selector: `.switchSignInSignUp`,
-        handler: () => this.setSignInForm(this.initialSignInForm),
+        handler: () => this.setState(this.initialSignInForm),
       },
     ];
   }

--- a/src/pages/SignInSignUp/SignUp.js
+++ b/src/pages/SignInSignUp/SignUp.js
@@ -9,14 +9,14 @@ import style from './SignInSignUp.module.css';
 export default class SignUp extends Component {
   constructor(props) {
     super(props);
-    const initialSignUpForm = {
+    this.initialSignUpForm = {
       email: { value: '', isDirty: false },
       name: { value: '', isDirty: false },
       password: { value: '', isDirty: false },
       confirmPassword: { value: '', isDirty: false },
       isSignUpFailed: false,
     };
-    [this.signUpForm, this.setSignUpForm] = this.useState(initialSignUpForm);
+    this.state = this.initialSignUpForm;
   }
 
   async checkDuplicatedEmail(inputEmail) {
@@ -24,7 +24,7 @@ export default class SignUp extends Component {
       const { data: isDuplicated } = await axios.post('/auth/checkDuplicated', { inputEmail });
 
       if (isDuplicated) {
-        this.setSignUpForm(prevState => ({ ...prevState, isSignUpFailed: true }));
+        this.setState(prevState => ({ ...prevState, isSignUpFailed: true }));
       }
     } catch (err) {
       console.log(err);
@@ -52,10 +52,10 @@ export default class SignUp extends Component {
   }
 
   render() {
-    const emailValue = this.signUpForm.email.value;
-    const nameValue = this.signUpForm.name.value;
-    const passwordValue = this.signUpForm.password.value;
-    const confirmPasswordValue = this.signUpForm.confirmPassword.value;
+    const emailValue = this.state.email.value;
+    const nameValue = this.state.name.value;
+    const passwordValue = this.state.password.value;
+    const confirmPasswordValue = this.state.confirmPassword.value;
     const isEmailValid = signUpSchema.email.isValid(emailValue);
     const isNameValid = !!nameValue;
     const isPasswordValid = signUpSchema.password.isValid(passwordValue);
@@ -71,30 +71,30 @@ export default class SignUp extends Component {
           style.input
         }" type="text" id="email" name="email" required autocomplete="off" value="${emailValue}"/>
         ${
-          this.signUpForm.email.isDirty
+          this.state.email.isDirty
             ? isEmailValid
               ? `<box-icon class="${style.icon} ${style.iconSuccess}" name='check-circle'></box-icon>`
               : `<box-icon class="${style.icon} ${style.iconError}" name='x-circle'></box-icon>`
             : ''
         }
         <div class="${style.validateError}">${
-      this.signUpForm.email.isDirty && !isEmailValid ? signUpSchema.email.error : ''
+      this.state.email.isDirty && !isEmailValid ? signUpSchema.email.error : ''
     }</div>
       </div>
       <div class="${style.inputContainer}">
         <label class="${style.label}" for="name">NAME</label>
         <input class="${style.input}" type="text" id="name" name="name" required autocomplete="off" value="${
-      this.signUpForm.name.value
+      this.state.name.value
     }"/>
     ${
-      this.signUpForm.name.isDirty
+      this.state.name.isDirty
         ? isNameValid
           ? `<box-icon class="${style.icon} ${style.iconSuccess}" name='check-circle'></box-icon>`
           : `<box-icon class="${style.icon} ${style.iconError}" name='x-circle'></box-icon>`
         : ''
     }
         <div class="${style.validateError}">${
-      this.signUpForm.name.isDirty && !isNameValid ? signUpSchema.name.error : ''
+      this.state.name.isDirty && !isNameValid ? signUpSchema.name.error : ''
     }</div>
       </div>
       <div class="${style.inputContainer}">
@@ -102,17 +102,17 @@ export default class SignUp extends Component {
         <input class="${
           style.input
         }" type="password" id="password" name="password" required autocomplete="off" value="${
-      this.signUpForm.password.value
+      this.state.password.value
     }"/>
     ${
-      this.signUpForm.password.isDirty
+      this.state.password.isDirty
         ? isPasswordValid
           ? `<box-icon class="${style.icon} ${style.iconSuccess}" name='check-circle'></box-icon>`
           : `<box-icon class="${style.icon} ${style.iconError}" name='x-circle'></box-icon>`
         : ''
     }
         <div class="validateError ${style.validateError}">${
-      this.signUpForm.password.isDirty && !isPasswordValid ? signUpSchema.password.error : ''
+      this.state.password.isDirty && !isPasswordValid ? signUpSchema.password.error : ''
     }</div>
       </div>
       <div class="${style.inputContainer}">
@@ -120,17 +120,17 @@ export default class SignUp extends Component {
         <input class="${
           style.input
         }" type="password" id="confirmPassword" name="confirmPassword" required autocomplete="off" value="${
-      this.signUpForm.confirmPassword.value
+      this.state.confirmPassword.value
     }"/>
     ${
-      this.signUpForm.confirmPassword.isDirty
+      this.state.confirmPassword.isDirty
         ? isConfirmPasswordValid
           ? `<box-icon class="${style.icon} ${style.iconSuccess}" name='check-circle'></box-icon>`
           : `<box-icon class="${style.icon} ${style.iconError}" name='x-circle'></box-icon>`
         : ''
     }
         <div class="validateError ${style.validateError}">${
-      this.signUpForm.confirmPassword.isDirty && !isConfirmPasswordValid ? signUpSchema.confirmPassword.error : ''
+      this.state.confirmPassword.isDirty && !isConfirmPasswordValid ? signUpSchema.confirmPassword.error : ''
     }</div>
       </div>
       <p class="signUpError ${style.authorizeError}"></p>
@@ -150,7 +150,7 @@ export default class SignUp extends Component {
         type: 'input',
         selector: `.${style.signUpForm} input`,
         handler: e => {
-          this.setSignUpForm(prevState => ({
+          this.setState(prevState => ({
             ...prevState,
             [e.target.name]: { value: e.target.value, isDirty: true },
           }));
@@ -169,7 +169,7 @@ export default class SignUp extends Component {
       {
         type: 'click',
         selector: `.switchSignInSignUp`,
-        handler: () => this.setSignUpForm(this.initialSignUpForm),
+        handler: () => this.setState(this.initialSignUpForm),
       },
     ];
   }

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -45,7 +45,7 @@ const generateNextId = arr => Math.max(...arr.map(item => item.id), 0) + 1;
 
 const getMembers = () => getGlobalState().organization.members;
 const setMembers = members => {
-  this.setState(prevState => ({
+  setGlobalState(prevState => ({
     ...prevState,
     organization: {
       ...prevState.organization,


### PR DESCRIPTION
- 렌더링&상태관리 구조를 전면 수정했습니다
  - 페이지 전환 시 상태가 올바르게 유지되지 않았음
- 기존 구조: 상태를 클로저로 유지하고 컴포넌트는 무조건 루트부터 리렌더링
- 변경된 구조: 상태가 변경된 컴포넌트의 자식부터 리렌더링
  - 구조가 변경됨에 따라, 이벤트 핸들러 등록도 부분적 업데이트 방식으로 변경하였습니다
  - 컴포넌트 단위로 무조건 래퍼 요소를 사용하게 하고, 라이브러리 내부에서 래퍼 요소에 componentId를 부여하여 렌더링과 이벤트 핸들러를 관리하였습니다