### PR TITLE
Refactor: Whole New Manage Member Page

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -58,6 +58,8 @@ input {
 :global .main {
   width: 100%;
   min-width: 40rem;
+  height: calc(100vh - 4rem);
+  overflow: hidden;
   background-color: rgba(247, 247, 247, 0.25);
   border-radius: 1rem;
   margin: 2rem 2rem 2rem 0;

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -59,7 +59,10 @@ input {
   width: 100%;
   min-width: 40rem;
   height: calc(100vh - 4rem);
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   background-color: rgba(247, 247, 247, 0.25);
   border-radius: 1rem;
   margin: 2rem 2rem 2rem 0;
@@ -67,7 +70,7 @@ input {
 }
 
 :global .title {
-  font-size: 3.4rem;
+  font-size: 3rem;
   text-align: center;
   color: rgb(39, 50, 84);
 }

--- a/src/pages/Members/MemberItem.js
+++ b/src/pages/Members/MemberItem.js
@@ -7,55 +7,80 @@ export default class MemberItem extends Component {
     const { id, name } = member;
     const isEditing = editingMember.id === id;
 
+    // TODO: data-name 없이?
+    // TODO: sanitize(https://www.npmjs.com/package/sanitize-html)
+    // TODO: 미묘한 padding 변화
+    // 입력값에 따라 길이가 달라지는 input: https://codepen.io/chaerin-dev/pen/gOdgPMN
     return `
-      <li class="${style.listItem} ${isEditing ? style.editing : ''}" data-id="${id}" data-name="${name}">
-        <div class="${style.view}">
-          <span class="${style.name}">${name}</span>
-          <button type="button" class="${style.removeBtn}">X</button>
-        </div>
-        <input type="text" value="${name}" class="${style.edit}" data-id="${id}" />
+      <li data-id="${id}" data-name="${name}" class="${style.memberItem}">
+        ${
+          isEditing
+            ? `<label data-value="${name}">
+                <input type="text" value="${name}" size="1" maxlength="20">
+              </label>`
+            : `<span>${name}</span>
+              <button aria-label="delete member">
+                <?xml version="1.0" encoding="utf-8"?>
+                <svg fill="#FFFFFF" width="20px" height="20px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12,23A11,11,0,1,0,1,12,11.013,11.013,0,0,0,12,23ZM12,3a9,9,0,1,1-9,9A9.01,9.01,0,0,1,12,3ZM8.293,14.293,10.586,12,8.293,9.707A1,1,0,0,1,9.707,8.293L12,10.586l2.293-2.293a1,1,0,0,1,1.414,1.414L13.414,12l2.293,2.293a1,1,0,1,1-1.414,1.414L12,13.414,9.707,15.707a1,1,0,0,1-1.414-1.414Z"/>
+                </svg>
+              </button>`
+        }
       </li>`;
   }
 
+  // TODO: 생명주기 함수 이용 -> 선택된 input 자동 포커스
+
   setEvent() {
     const { openModal, onUpdate, toggleEditMode, editingMember } = this.props;
+
+    // TODO: 이벤트 중복 해결
     return [
       {
-        type: 'click',
-        selector: `.${style.removeBtn}`,
+        type: 'input',
+        selector: `.${style.memberItem} input`,
         handler: e => {
-          const id = +e.target.closest(`.${style.listItem}`).dataset.id;
+          console.log('INPUT EVENT');
+          e.target.closest('label').dataset.value = e.target.value;
+        },
+      },
+      {
+        type: 'keydown',
+        selector: `.${style.memberItem} input`,
+        handler: e => {
+          if (e.key === 'Enter') {
+            const id = +e.target.closest(`.${style.memberItem}`).dataset.id;
+            const trimmedValue = e.target.value.trim();
+            if (editingMember.name === trimmedValue || trimmedValue === '') {
+              toggleEditMode({ id: null, name: null });
+              return;
+            }
+            console.log('UPDATE MEMBER');
+            onUpdate({ id, name: trimmedValue });
+          }
+
+          if (e.key === 'Escape') {
+            console.log('KEYDOWN ESC');
+            console.log('TOGGLE EDIT MODE');
+            toggleEditMode({ id: null, name: null });
+          }
+        },
+      },
+      {
+        type: 'click',
+        selector: `.${style.memberItem} button`,
+        handler: e => {
+          const id = +e.target.closest(`.${style.memberItem}`).dataset.id;
           openModal(id);
         },
       },
       {
-        type: 'dblclick',
-        selector: `.${style.listItem}`,
+        type: 'click',
+        selector: `.${style.memberItem}`,
         handler: e => {
-          const $li = e.target.closest(`.${style.listItem}`);
+          const $li = e.target.closest(`.${style.memberItem}`);
           const { id, name } = $li.dataset;
           toggleEditMode({ id: +id, name });
-
-          $li.lastElementChild.setSelectionRange(0, -1);
-          $li.lastElementChild.focus();
-        },
-      },
-      {
-        type: 'keyup',
-        selector: `.${style.edit}[data-id="${this.props.member.id}"]`,
-        handler: e => {
-          if (e.key !== 'Enter') {
-            return;
-          }
-
-          const id = +e.target.closest(`.${style.listItem}`).dataset.id;
-          const name = e.target.value;
-          if (editingMember.id === id && editingMember.name === name) {
-            toggleEditMode({ id: null, name: null });
-            return;
-          }
-
-          onUpdate({ id, name });
         },
       },
     ];

--- a/src/pages/Members/MemberList.js
+++ b/src/pages/Members/MemberList.js
@@ -6,7 +6,7 @@ import 'boxicons';
 
 export default class MemberList extends Component {
   DOMStr() {
-    const { openModal, onUpdate, toggleEditMode, editingMember } = this.props;
+    const { editingMember, toggleEditMode, onUpdate, openModal } = this.props;
 
     // prettier-ignore
     return `
@@ -16,50 +16,11 @@ export default class MemberList extends Component {
             new MemberItem({
               member,
               editingMember,
-              openModal,
-              onUpdate,
               toggleEditMode,
+              onUpdate,
+              openModal,
             }).render()
-          )
-          .join('')}
-        <li class="${style.listItem} ${editingMember.id === style.addBtn ? style.editing : ''}" >
-          <div class="${style.view}">
-            <button type="button" class="${style.addBtn}">
-              <box-icon name='plus-circle' class="${style.icon}"></box-icon>
-            </button>
-          </div>
-          <input type="text" class="${style.edit} addMember" />
-        </li>
+          ).join('')}
       </ul>`;
-  }
-
-  setEvent() {
-    const { toggleEditMode, onAdd } = this.props;
-    return [
-      {
-        type: 'click',
-        selector: `.${style.addBtn}`,
-        handler: e => {
-          const $li = e.target.closest(`.${style.listItem}`);
-          const id = style.addBtn;
-          toggleEditMode({ id, name: null });
-
-          $li.lastElementChild.setSelectionRange(0, -1);
-          $li.lastElementChild.focus();
-        },
-      },
-      {
-        type: 'keyup',
-        selector: `.${style.edit}.addMember`,
-        handler: e => {
-          if (e.key !== 'Enter') {
-            return;
-          }
-
-          const name = e.target.value;
-          onAdd(name);
-        },
-      },
-    ];
   }
 }

--- a/src/pages/Members/Members.js
+++ b/src/pages/Members/Members.js
@@ -1,9 +1,8 @@
 import { Component } from '../../../library/CBD/index.js';
 import MainLayout from '../../components/MainLayout/MainLayout.js';
 import DeleteModal from '../../components/Modals/DeleteModal.js';
-import { addMember, isDuplicatedMemberName, removeMember, updateMember } from '../../state/index.js';
 import MemberList from './MemberList.js';
-
+import { addMember, isDuplicatedMemberName, removeMember, updateMember } from '../../state/index.js';
 import style from './Members.module.css';
 
 export default class Members extends Component {
@@ -22,27 +21,32 @@ export default class Members extends Component {
   DOMStr() {
     // prettier-ignore
     return `
-    <div class="mainContainer">
-      ${new MainLayout().render()}
-      <main class="main">
-        <h2 class="title">Manage Members</h2>
-        <pre class="${style.guide}">Double click & press Enter to edit name</pre>
-        ${new MemberList({
-          editingMember: this.state.editingMember,
-          toggleEditMode: this.toggleEditMode.bind(this),
-          onAdd: this.onAdd.bind(this),
-          onUpdate: this.onUpdate.bind(this),
-          openModal: this.openModal.bind(this),
-        }).render()}
-      </main>
-      ${this.state.isModalOpen
-        ? new DeleteModal({
-            target: 'member',
-            onRemove: this.onRemove.bind(this),
-            closeModal: this.closeModal.bind(this),
-          }).render()
-        : ''}
-    </div>`;
+      <div class="mainContainer">
+        ${new MainLayout().render()}
+        <main class="main">
+          <h2 class="title">Manage Members</h2>
+          <pre class="${
+            style.guide
+          }">Double-click name to edit. When you are done, press Enter.</pre>
+          ${new MemberList({
+            editingMember: this.state.editingMember,
+            toggleEditMode: this.toggleEditMode.bind(this),
+            onUpdate: this.onUpdate.bind(this),
+            openModal: this.openModal.bind(this),
+          }).render()}
+          <form class="${style.addMemberForm}">
+            <input type="text" maxlength="20" autofocus=${true}/>
+            <button type="submit">Add member</button>
+          </form>
+        </main>
+        ${this.state.isModalOpen
+            ? new DeleteModal({
+                target: 'member',
+                onRemove: this.onRemove.bind(this),
+                closeModal: this.closeModal.bind(this),
+              }).render()
+            : ''}
+      </div>`;
   }
 
   toggleEditMode(editingMember) {
@@ -53,29 +57,21 @@ export default class Members extends Component {
   }
 
   onAdd(name) {
-    if (name.trim() === '') {
-      this.toggleEditMode({ id: null, name: null });
+    if (isDuplicatedMemberName(name)) {
+      alert('중복된 이름입니다.');
       return;
     }
 
-    if (isDuplicatedMemberName(name)) {
-      alert('중복금지!중복금지!!');
-      return;
-    }
     addMember(name);
   }
 
   onUpdate({ id, name }) {
-    if (name.trim() === '') {
-      this.toggleEditMode({ id: null, name: null });
-      return;
-    }
-
     if (isDuplicatedMemberName(name)) {
-      alert('중복금지!중복금지!!');
+      alert('중복된 이름입니다.');
       return;
     }
 
+    console.log('XXXX');
     updateMember({ id, name });
   }
 
@@ -89,5 +85,24 @@ export default class Members extends Component {
 
   closeModal() {
     this.setState(prevState => ({ ...prevState, isModalOpen: false, removeMemberId: null }));
+  }
+
+  setEvent() {
+    return [
+      // TODO: sanitize
+      // TODO: 멤버 입력시 scrollable 요소의 bottom으로! 즉, 방금 추가된 멤버가 보이도록
+      {
+        type: 'submit',
+        selector: `.${style.addMemberForm}`,
+        handler: e => {
+          e.preventDefault();
+
+          const trimmedValue = e.target.querySelector('input').value.trim();
+          if (trimmedValue !== '') {
+            this.onAdd(trimmedValue);
+          }
+        },
+      },
+    ];
   }
 }

--- a/src/pages/Members/Members.module.css
+++ b/src/pages/Members/Members.module.css
@@ -1,114 +1,130 @@
+/* [Members.js] */
+
+.guide {
+  max-width: 100%;
+  margin-top: 1rem;
+  font-size: 1.2rem;
+  text-align: center;
+  white-space: normal;
+  word-break: keep-all;
+  color: rgb(39, 50, 84, 0.7);
+}
+
+.addMemberForm input {
+  width: 13rem;
+  height: 2rem;
+  padding: 0 0.5rem;
+  border: solid 1px rgb(39, 50, 84, 0.5);
+  border-radius: 4px;
+  background-color: rgba(247, 247, 247, 0.5);
+}
+
+.addMemberForm button {
+  width: 6rem;
+  height: 2rem;
+  margin-left: 0.5rem;
+  border-radius: 4px;
+  background-color: rgba(247, 247, 247, 0.5);
+}
+
+.addMemberForm button:hover {
+  background-color: rgba(247, 247, 247, 0.7);
+}
+
+/* ---------------------------------------- */
+
+/* [MemberList.js] */
+
 .list {
+  width: 100%;
+  flex-grow: 1;
+  margin: 1.5rem 2rem;
+  padding: 2rem;
   display: flex;
   flex-flow: row wrap;
-  justify-content: center;
+  justify-content: space-evenly;
   align-items: center;
-  gap: 1.2rem;
-  /* padding: 0 2rem 2rem; */
-  max-height: 30rem;
+  gap: 1rem;
   overflow-y: scroll;
-  overflow-x: hidden;
+  border: 3px solid rgba(247, 247, 247, 0.5);
+  border-radius: 8px;
 }
 
 .list::-webkit-scrollbar {
   width: 0.8rem;
 }
+
 .list::-webkit-scrollbar-thumb {
-  background-color: rgba(144, 30, 184, 0.2);
-  border-radius: 1rem;
+  background-color: rgba(247, 247, 247, 0.5);
+  /* TODO: 스크롤과 list border가 겹치는 부분 해결 */
+  border-radius: 4px;
 }
-.listItem {
+
+/* ---------------------------------------- */
+
+/* [MemberItem.js] */
+
+.memberItem {
+  display: block;
   position: relative;
-  display: flex;
-  justify-content: center;
+}
+
+.memberItem span,
+.memberItem input {
+  display: block;
+  font-family: inherit;
+  font-size: inherit;
+  border-radius: 1rem;
+  border: solid 1px rgb(39, 50, 84, 0.5);
+}
+
+/* TODO: span과 input의 미묘한 너비차이 해결 */
+
+.memberItem span {
+  padding: 1rem 2.2rem;
+  background-color: rgba(247, 247, 247, 0.5);
+}
+
+.memberItem input {
+  padding: 1rem 2rem;
+  background-color: rgba(247, 247, 247, 0.7);
+}
+
+.memberItem label {
+  display: inline-grid;
+  vertical-align: top;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
-  margin-top: 5%;
-  width: 12rem;
-  height: 5rem;
-  background: rgba(173, 171, 171, 0.316);
-  border: 2px solid #ffffff;
-  border-radius: 20px;
-  transition: all 200ms;
-}
-.listItem:hover {
-  background: rgba(247, 247, 247, 0.6);
+  position: relative;
+  font-family: inherit;
+  font-size: inherit;
 }
 
-.name {
-  font-size: 1.6rem;
+.memberItem label::after {
+  content: attr(data-value);
+  visibility: hidden;
+  height: 0;
+  padding: 0 2.2rem;
+  font-family: inherit;
+  font-size: inherit;
+  white-space: pre-wrap;
 }
 
-.removeBtn {
+.memberItem button {
   position: absolute;
-  top: 0;
-  right: 0;
-  display: flex;
+  top: -0.3rem;
+  right: -0.3rem;
+  display: none;
   justify-content: center;
   align-items: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  font-size: 1.6rem;
-  color: rgb(189, 64, 64);
-  background-color: #ddd;
-  /* border: 2px solid #000; */
+  width: 23px;
+  height: 23px;
   border-radius: 50%;
-  opacity: 0;
-  transform: translate3D(50%, -50%, 0);
-  transition: opacity 120ms;
-  transition: background-color 220ms;
-}
-.listItem:hover .removeBtn,
-.removeBtn:hover {
-  opacity: 1;
-}
-.removeBtn:hover {
-  background-color: #999;
+  background-color: rgb(189, 64, 64);
 }
 
-.listItem.editing .view {
-  display: none;
-}
-.listItem.editing .edit {
-  display: block;
-}
-
-.edit {
-  display: none;
-  width: 100%;
-  height: 100%;
-  font-size: 2rem;
-  text-align: center;
-  border: 1px solid #ffffff;
-  border-radius: 20px;
-}
-.edit:focus {
-  outline: none;
-}
-
-.addBtn {
+.memberItem:hover button {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 3rem;
-  height: 3rem;
-  font-size: 6rem;
-  background: rgba(77, 37, 190, 0.28);
-  border-radius: 50%;
-  color: rgb(39, 50, 84);
-}
-
-.listItem.editing .edit {
-  display: block;
-}
-
-.icon {
-  width: 10rem;
-  height: 10rem;
-}
-
-.guide {
-  padding: 1rem 0;
-  font-size: 1.5rem;
-  text-align: center;
-  color: rgb(39, 50, 84, 0.7);
+  transition: all 0.3s;
 }

--- a/src/pages/NewGroup/Result.js
+++ b/src/pages/NewGroup/Result.js
@@ -2,7 +2,7 @@ import { throttle } from 'lodash';
 import { Component } from '../../../library/CBD/index.js';
 import Members from '../../components/Result/Members.js';
 import Groups from '../../components/Result/Groups.js';
-import { addRecord, getActiveMemberIds } from '../../state/index.js';
+import { addRecord, getActiveMembers } from '../../state/index.js';
 import style from './Result.module.css';
 
 export default class Result extends Component {
@@ -21,7 +21,7 @@ export default class Result extends Component {
     } = this.props;
 
     this.state = {
-      memberArr: currentView === 'autoResult' ? [] : getActiveMemberIds(),
+      memberArr: currentView === 'autoResult' ? [] : getActiveMembers().map(member => member.id),
       groupArr: result,
     };
   }
@@ -100,12 +100,12 @@ export default class Result extends Component {
     const group2 = this.getGroupId($node2);
 
     this.setState(prevState => {
-      let groupArr = prevState.groupArr;
+      const { groupArr } = prevState;
       [groupArr[group1], groupArr[group2]] = [groupArr[group2], groupArr[group1]];
 
       return {
         ...prevState,
-        groupArr: groupArr,
+        groupArr,
       };
     });
   }
@@ -155,7 +155,9 @@ export default class Result extends Component {
 
     if (this.$dragTarget.matches(`.${style.member}`)) {
       this.$targetzone = e.target.closest('.dropzone');
-      if (this.$targetzone === this.$startzone) return;
+      if (this.$targetzone === this.$startzone) {
+        return;
+      }
 
       this.$startzone = this.$targetzone;
       this.$targetzone.children[0].appendChild(this.$dragTarget);
@@ -172,18 +174,18 @@ export default class Result extends Component {
         const to = this.getGroupId(this.$targetzone);
         const targetId = this.getMemberId(this.$dragTarget);
 
-        this.setState(({ memberArr, groupArr }) => {
-          return {
-            memberArr: memberArr.filter(member => member !== targetId),
-            groupArr: groupArr.map((group, id) => (id === to ? [...group, targetId] : group)),
-          };
-        });
+        this.setState(({ memberArr, groupArr }) => ({
+          memberArr: memberArr.filter(member => member !== targetId),
+          groupArr: groupArr.map((group, id) => (id === to ? [...group, targetId] : group)),
+        }));
       }
     }
 
     // from group
     if (this.$dragTarget.matches(`.${style.member}`) && this.$initTargetzone.matches(`.${style.group}`)) {
-      if (this.$targetzone === this.$initTargetzone) return;
+      if (this.$targetzone === this.$initTargetzone) {
+        return;
+      }
 
       // to group
       if (e.target.closest('.dropzone').matches(`.${style.group}`)) {
@@ -209,7 +211,7 @@ export default class Result extends Component {
         this.setState(({ memberArr, groupArr }) => {
           memberArr.push(targetId);
           return {
-            memberArr: memberArr,
+            memberArr,
             groupArr: groupArr.map(group => group.filter(member => member !== targetId)),
           };
         });
@@ -219,7 +221,9 @@ export default class Result extends Component {
     if (this.$dragTarget.matches(`.${style.group}`)) {
       this.$dropTarget = e.target.closest(`.${style.group}`) ?? null;
 
-      if (!this.$dropTarget || this.$dragTarget === this.$dropTarget) return;
+      if (!this.$dropTarget || this.$dragTarget === this.$dropTarget) {
+        return;
+      }
 
       this.swap(this.$dropTarget, this.$dragTarget);
     }


### PR DESCRIPTION
- 우측 main 영역이 화면 비율에 관계없이 크기를 유지하도록 CSS를 수정하였습니다.

- Manage Member Page를 전반적으로 수정하였습니다.
  - MemberItem Component
    - class toggle로 span <-> input 변경하던 코드를 상태에 따라 선언적으로 변경
    - MemberItem 요소의 너비가 member name에 따라 유동적으로 달라지도록 변경
    - input value trim 처리를 데이터 조작 함수 처리 이전에 하도록 변경
    - 멤버 이름 수정 중에 Enter를 입력하면 수정 내용 확정 처리
    - 멤버 이름 수정 중에 ESC를 입력하면 수정 취소 처리
  - MemberList Component
    - 가독성을 위한 prop 순서 통일
  - Members Component
    - guide 내용 디테일하게 변경
    - 불필요한 함수 삭제
    - 새로운 멤버 추가를 위한 form 추가
    - trim 처리 코드 함수 호출 부분으로 이동

Resolves #48 