### PR TITLE
Fix: Resolve eventhandler bug

### DIFF
--- a/library/CBD/component.js
+++ b/library/CBD/component.js
@@ -45,7 +45,16 @@ class Component {
       const eventHandlers = this.setEvent();
       validateEventHandlerInfo(eventHandlers);
 
-      this.eventHandlers = eventHandlers;
+      this.eventHandlers = eventHandlers.map(handlerInfo => {
+        const { selector, handler } = handlerInfo;
+        const wrappedHandler = e => {
+          if (e.target.closest(selector)) {
+            handler(e);
+          }
+        };
+
+        return { ...handlerInfo, id: this.id, handler: wrappedHandler };
+      });
     }
   }
 }

--- a/library/CBD/eventHandler.js
+++ b/library/CBD/eventHandler.js
@@ -29,22 +29,20 @@ const validateEventHandlerInfo = eventHandlers => {
 };
 
 const subscribeEvents = eventHandlers => {
-  eventHandlers.forEach(eventHandler => {
-    const { selector, handler, type } = eventHandler;
-    const wrappedHandler = e => {
-      if (selector === 'window' || selector === 'document' || e.target.closest(selector)) {
-        handler(e);
-      }
-    };
+  eventHandlers.forEach(handlerInfo => {
+    const { id, type, handler } = handlerInfo;
+    const $container = document.querySelector(`[data-component-id="${id}"]`);
 
-    window.addEventListener(type, wrappedHandler);
+    $container.addEventListener(type, handler);
   });
 };
 
 const unSubscribeEvents = eventHandlers => {
   eventHandlers.forEach(handlerInfo => {
-    const { type, handler } = handlerInfo;
-    window.removeEventListener(type, handler);
+    const { id, type, handler } = handlerInfo;
+    const $container = document.querySelector(`[data-component-id="${id}"]`);
+
+    $container.removeEventListener(type, handler);
   });
 };
 

--- a/src/pages/NewGroup/Result.js
+++ b/src/pages/NewGroup/Result.js
@@ -34,7 +34,7 @@ export default class Result extends Component {
 
     // prettier-ignore
     return `
-      <div>
+      <div class="container">
         <h2 class="title">Result</h2>
         <h3 class="${style.subTitle}">MemberList</h3>
         <div class="dropzone ${style.members}">
@@ -66,12 +66,12 @@ export default class Result extends Component {
       },
       {
         type: 'dragstart',
-        selector: 'document',
+        selector: '.container',
         handler: this.onDragstart.bind(this),
       },
       {
         type: 'dragend',
-        selector: 'document',
+        selector: '.container',
         handler: this.onDragend.bind(this),
       },
       {
@@ -81,7 +81,7 @@ export default class Result extends Component {
       },
       {
         type: 'drop',
-        selector: 'document',
+        selector: '.container',
         handler: this.onDrop.bind(this),
       },
     ];


### PR DESCRIPTION
## 수정 사항

- id 프로퍼티를 활용하여 컴포넌트의 컨테이너 요소에 이벤트를 위임하도록 수정하였습니다
	- 하나의 컴포넌트로 여러 개의 인스턴스를 렌더링 하더라도 이벤트 핸들러가 중복 호출되지 않음
	-> 멤버 수정 alert이 무한 반복되던 버그 해결
- 이벤트 핸들러를 제대로 해제하도록 수정하였습니다
	- 구현 오류로 이전에 등록된 이벤트 핸들러가 삭제되지 않고 있던 부분 해결
	-> 페이지 이동, 멤버 삭제 등 컴포넌트 리렌더링 이후 모든 동작이 불가능하던 버그 해결

## 요청사항
- ~~setEvent함수 관련 기존 코드 일부 수정 필요~~
  - ~~자연스러운 동작 흐름을 위해 window / document 등 컴포넌트 외부를 selector로 하는 이벤트 핸들러는 생명주기 메서드 안에서 직접 바인딩하도록 내부 로직을 수정하였습니다.~~
  - ~~따라서 현재 selector로 document를 참조하는 Result 페이지 컴포넌트의 코드를 수정해야할 것 같습니다~~
- 수정 완료

resolve #52 